### PR TITLE
Fix trend by updating current and previous results on different intervals

### DIFF
--- a/webstats.exe.config.server
+++ b/webstats.exe.config.server
@@ -9,5 +9,7 @@
         <add key="ResultsFile" value="wc2018-actual.toml" />
         <add key="LiveResultsUrl" value=""/>
         <add key="LiveResultsInterval" value=""/> 
+        <add key="LiveResultsIntervalCurrent" value=""/>
+        <add key="LiveResultsIntervalPrevious" value=""/>
     </appSettings>
 </configuration>

--- a/webstats/Modules/Bootstrapper.cs
+++ b/webstats/Modules/Bootstrapper.cs
@@ -44,7 +44,8 @@ namespace Modules
             container.Register<ISubmittedBets, SubmittedBets>(bets);
 
             if (!string.IsNullOrWhiteSpace(ConfigurationManager.AppSettings["LiveResultsUrl"]) &&
-                !string.IsNullOrWhiteSpace(ConfigurationManager.AppSettings["LiveResultsInterval"]))
+                !string.IsNullOrWhiteSpace(ConfigurationManager.AppSettings["LiveResultsIntervalCurrent"]) &&
+                !string.IsNullOrWhiteSpace(ConfigurationManager.AppSettings["LiveResultsIntervalPrevious"]))
             {
                 RegisterLiveResultsCollection(container, tournament);
             }
@@ -64,12 +65,15 @@ namespace Modules
             var resultCollection = new LiveResultsCollection
             {
                 Current = new LiveResults(tournament),
-                Previous = new LiveResults(tournament)
+                Previous = new LiveResults(tournament),
+                Backup = new LiveResults(tournament)
             };
             resultCollection.Current.Load(ConfigurationManager.AppSettings["LiveResultsUrl"]);
             resultCollection.Previous.Load(ConfigurationManager.AppSettings["LiveResultsUrl"]);
+            resultCollection.Backup.Load(ConfigurationManager.AppSettings["LiveResultsUrl"]);
 
-            Task.Run(async () => { await resultCollection.UpdateResultsAsync(new TimeSpan(0, int.Parse(ConfigurationManager.AppSettings["LiveResultsInterval"]), 0)); });
+            Task.Run(async () => { await resultCollection.UpdateCurrentResultsAsync(new TimeSpan(0, int.Parse(ConfigurationManager.AppSettings["LiveResultsIntervalCurrent"]), 0)); });
+            Task.Run(async () => { await resultCollection.UpdatePreviousResultsAsync(new TimeSpan(0, int.Parse(ConfigurationManager.AppSettings["LiveResultsIntervalPrevious"]), 0)); });
             container.Register<IResultCollection, LiveResultsCollection>(resultCollection);
         }
 

--- a/webstats/SubmittedData/ILiveResultsCollection.cs
+++ b/webstats/SubmittedData/ILiveResultsCollection.cs
@@ -12,7 +12,11 @@ namespace SubmittedData
 
         new ILiveResults Previous { get; set; }
 
+        new ILiveResults Backup { get; set; }
+
         Task UpdateResultsAsync(TimeSpan interval);
+        Task UpdateCurrentResultsAsync(TimeSpan interval);
+        Task UpdatePreviousResultsAsync(TimeSpan interval);
     }
 
 }

--- a/webstats/SubmittedData/IResultCollection.cs
+++ b/webstats/SubmittedData/IResultCollection.cs
@@ -5,6 +5,7 @@ namespace SubmittedData
 	{
 		IResults Current { get; set; }
 		IResults Previous { get; set; }
+		IResults Backup { get; set; }
 	}
 }
 

--- a/webstats/SubmittedData/LiveResultsCollection.cs
+++ b/webstats/SubmittedData/LiveResultsCollection.cs
@@ -7,25 +7,37 @@ namespace SubmittedData
     public class LiveResultsCollection : ILiveResultsCollection, IDisposable
     {
         private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly CancellationTokenSource _cancellationTokenSourceCurrent;
+        private readonly CancellationTokenSource _cancellationTokenSourcePrevious;
 
         public LiveResultsCollection()
         {
             _cancellationTokenSource = new CancellationTokenSource();
+            _cancellationTokenSourceCurrent = new CancellationTokenSource();
+            _cancellationTokenSourcePrevious = new CancellationTokenSource();
         }
-        public ILiveResults Current { get; set; }
+
+        public ILiveResults Previous { get; set; }
         IResults IResultCollection.Previous
         {
             get => Previous;
             set => Previous = value as ILiveResults;
         }
 
+        public ILiveResults Current { get; set; }
         IResults IResultCollection.Current
         {
             get => Current;
             set => Current = (ILiveResults) value;
         }
 
-        public ILiveResults Previous { get; set; }
+        public ILiveResults Backup { get; set; }
+        IResults IResultCollection.Backup
+        {
+            get => Backup;
+            set => Backup = value as ILiveResults;
+        }
+
 
         public async Task UpdateResultsAsync(TimeSpan interval)
         {
@@ -36,6 +48,43 @@ namespace SubmittedData
                 await Task.Delay(interval, _cancellationTokenSource.Token);
                 if (_cancellationTokenSource.IsCancellationRequested)
                     break;
+            }
+        }
+
+        public async Task UpdateCurrentResultsAsync(TimeSpan interval)
+        {
+            await Task.Delay(interval, _cancellationTokenSourceCurrent.Token);
+            while (true)
+            {
+                UpdateResults(Current);
+                await Task.Delay(interval, _cancellationTokenSourceCurrent.Token);
+                if (_cancellationTokenSourceCurrent.IsCancellationRequested)
+                    break;
+            }
+        }
+
+        public async Task UpdatePreviousResultsAsync(TimeSpan interval)
+        {
+            await Task.Delay(interval, _cancellationTokenSourcePrevious.Token);
+            while (true)
+            {
+                UpdateResults(Previous);
+                await Task.Delay(interval, _cancellationTokenSourcePrevious.Token);
+                if (_cancellationTokenSourcePrevious.IsCancellationRequested)
+                    break;
+            }
+        }
+
+        private void UpdateResults(ILiveResults results)
+        {
+            Backup.Copy(Current);
+            try
+            {
+                results.Load(null);
+            }
+            catch
+            {
+                results.Copy(Backup);
             }
         }
 
@@ -56,6 +105,11 @@ namespace SubmittedData
         {
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();
+            _cancellationTokenSourceCurrent.Cancel();
+            _cancellationTokenSourceCurrent.Dispose();
+            _cancellationTokenSourcePrevious.Cancel();
+            _cancellationTokenSourcePrevious.Dispose();
         }
+
     }
 }

--- a/webstats/SubmittedData/ResultCollection.cs
+++ b/webstats/SubmittedData/ResultCollection.cs
@@ -7,6 +7,8 @@ namespace SubmittedData
 		public IResults Current { get; set; }
 
 		public IResults Previous { get; set; }
-	}
+
+        public IResults Backup { get; set; }
+    }
 }
 

--- a/webstats/webstats/app.config
+++ b/webstats/webstats/app.config
@@ -9,5 +9,7 @@
     <add key="ResultsFile" value="wc2018-actual.toml" />
     <add key="LiveResultsUrl" value=""/>
     <add key="LiveResultsInterval" value=""/>
+    <add key="LiveResultsIntervalCurrent" value=""/>
+    <add key="LiveResultsIntervalPrevious" value=""/>
   </appSettings>
 </configuration>


### PR DESCRIPTION
With the introduction of LiveResults the trend indicator doesn't work well. The reason being that both current and previous results update at the same time. The trend only lasts as long as the time interval. With an interval of e.g. 5 minutes the trend isn't visible for more than five minutes after the results have changed, which doesn't happen often.

Trying to fix this by splitting the update of Current and Previous results into separate update intervals. The idea is that we can keep the update of Current results on five minute interval, but use a longer interval for updating Previous results, e.g 24 hours. Then you only compare the current results to the previous days results 

I am not sure if this is the right way to manage two parallell async methods.